### PR TITLE
Add Slack to social software section (Ubuntu only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ include software::idesdk::android_tools
 include software::prefpanes::hosts
 include software::prefpanes::launchrocket
 include software::social::skype
+include software::social::slack
 include software::storage::drive
 include software::storage::fetch
 include software::storage::filezilla

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -65,8 +65,6 @@ class software::params (
     #### social ####
     $skype_version = '7.33.206'
     $skype_url     = "http://download.skype.com/macosx/59bb2e5bac07f54c8d4ade192fa36d1c/Skype_${skype_version}.dmg"
-    $slack_version = '2.7.1'
-    $slack_url     = "https://downloads.slack-edge.com/linux_releases/slack-desktop-${slack_version}-${::architecture}.deb"
 
 
     #### storage ####

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -65,6 +65,8 @@ class software::params (
     #### social ####
     $skype_version = '7.33.206'
     $skype_url     = "http://download.skype.com/macosx/59bb2e5bac07f54c8d4ade192fa36d1c/Skype_${skype_version}.dmg"
+    $slack_version = '2.7.1'
+    $slack_url     = "https://downloads.slack-edge.com/linux_releases/slack-desktop-${slack_version}-${::architecture}.deb"
 
 
     #### storage ####

--- a/manifests/social/slack.pp
+++ b/manifests/social/slack.pp
@@ -1,23 +1,34 @@
 # slack.pp
 # Install Slack for OS X, Ubuntu, or Windows
-# https://www.slack.com
+# https://www.slack.com, https://packagecloud.io/slacktechnologies
 #
 
 class software::social::slack (
-  $ensure  = $software::params::software_ensure,
+  $ensure = $software::params::software_ensure,
 ) inherits software::params {
 
   validate_string($ensure)
 
   case $::operatingsystem {
     'Ubuntu': {
-      # from https://packagecloud.io/slacktechnologies/slack/install#puppet
-      include '::apt'
-      include packagecloud
+      $apt_source_ensure = $ensure ? {
+        'installed' => present,
+        'latest'    => present,
+        default     => $ensure,
+      }
 
-      packagecloud::repo { 'slacktechnologies/slack':
-        type => 'deb',
-      } -> Class['apt::update'] ->
+      include '::apt'
+      apt::source { 'slack':
+        ensure   => $apt_source_ensure,
+        comment  => 'Slack APT sources for any Debian-based distribution, including Ubuntu',
+        location => 'https://packagecloud.io/slacktechnologies/slack/debian',
+        release  => 'jessie',
+        repos    => 'main',
+        key      => {
+          'id'     => 'C6ABDCF64DB9A0B2',
+          'source' => 'https://packagecloud.io/slacktechnologies/slack/gpgkey',
+        },
+      }
 
       package { 'slack-desktop':
         ensure => $ensure,

--- a/manifests/social/slack.pp
+++ b/manifests/social/slack.pp
@@ -1,0 +1,36 @@
+# slack.pp
+# Install Slack for OS X, Ubuntu, or Windows
+# https://www.slack.com
+#
+
+class software::social::slack (
+  $ensure  = $software::params::software_ensure,
+  $version = $software::params::slack_version,
+  $url     = $software::params::slack_url,
+) inherits software::params {
+
+  validate_string($ensure)
+
+  case $::operatingsystem {
+    'Ubuntu': {
+      $package = "slack-desktop-${version}-${::architecture}.deb"
+
+      archive { $package:
+        source  => $url,
+        path    => "/tmp/${package}",
+        extract => false,
+        cleanup => false,
+      }
+
+      package { 'slack-desktop':
+        ensure   => $ensure,
+        source   => "/tmp/${package}",
+        provider => 'dpkg',
+      }
+    }
+    default: {
+      fail("The ${name} class is not supported on ${::operatingsystem}.")
+    }
+  }
+
+}

--- a/manifests/social/slack.pp
+++ b/manifests/social/slack.pp
@@ -28,7 +28,7 @@ class software::social::slack (
           'id'     => 'C6ABDCF64DB9A0B2',
           'source' => 'https://packagecloud.io/slacktechnologies/slack/gpgkey',
         },
-      }
+      } -> Class['apt::update'] ->
 
       package { 'slack-desktop':
         ensure => $ensure,

--- a/manifests/social/slack.pp
+++ b/manifests/social/slack.pp
@@ -5,27 +5,22 @@
 
 class software::social::slack (
   $ensure  = $software::params::software_ensure,
-  $version = $software::params::slack_version,
-  $url     = $software::params::slack_url,
 ) inherits software::params {
 
   validate_string($ensure)
 
   case $::operatingsystem {
     'Ubuntu': {
-      $package = "slack-desktop-${version}-${::architecture}.deb"
+      # from https://packagecloud.io/slacktechnologies/slack/install#puppet
+      include '::apt'
+      include packagecloud
 
-      archive { $package:
-        source  => $url,
-        path    => "/tmp/${package}",
-        extract => false,
-        cleanup => false,
-      }
+      packagecloud::repo { 'slacktechnologies/slack':
+        type => 'deb',
+      } -> Class['apt::update'] ->
 
       package { 'slack-desktop':
-        ensure   => $ensure,
-        source   => "/tmp/${package}",
-        provider => 'dpkg',
+        ensure => $ensure,
       }
     }
     default: {

--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
     {"name": "puppetlabs/apt", "version_requirement": ">= 2.1.1 < 3.0.0"},
     {"name": "puppetlabs/chocolatey", "version_requirement": ">= 0.8.0 < 2.0.0"},
     {"name": "puppetlabs/vcsrepo", "version_requirement": ">= 2.0.0 < 3.0.0"},
-    {"name": "puppet/archive", "version_requirement": ">= 1.3.0 < 2.0.0"},
+    {"name": "computology/packagecloud", "version_requirement": ">= 0.3.2 < 0.4.0"},
     {"name": "thekevjames/homebrew", "version_requirement": ">= 1.5.0 < 2.0.0"},
     {"name": "unibet/vagrant", "version_requirement": ">= 0.2.1 < 1.0.0"}
   ],

--- a/metadata.json
+++ b/metadata.json
@@ -7,13 +7,19 @@
   "source": "https://github.com/edestecd/puppet-software.git",
   "project_page": "https://github.com/edestecd/puppet-software",
   "issues_url": "https://github.com/edestecd/puppet-software/issues",
-  "tags": ["desktop", "software", "graphical", "gui", "browser", "chrome", "firefox", "editors", "atom", "textmate"],
+  "tags": [
+    "desktop", "software", "graphical", "gui",
+    "browser", "chrome", "firefox",
+    "editors", "atom", "textmate",
+    "social", "chat", "skype", "slack"
+  ],
   "description": "The software module provides classes to install many commonly needed Desktop Applications",
   "dependencies": [
     {"name": "puppetlabs/stdlib", "version_requirement": ">= 4.2.0 < 5.0.0"},
     {"name": "puppetlabs/apt", "version_requirement": ">= 2.1.1 < 3.0.0"},
     {"name": "puppetlabs/chocolatey", "version_requirement": ">= 0.8.0 < 2.0.0"},
     {"name": "puppetlabs/vcsrepo", "version_requirement": ">= 2.0.0 < 3.0.0"},
+    {"name": "puppet/archive", "version_requirement": ">= 1.3.0 < 2.0.0"},
     {"name": "thekevjames/homebrew", "version_requirement": ">= 1.5.0 < 2.0.0"},
     {"name": "unibet/vagrant", "version_requirement": ">= 0.2.1 < 1.0.0"}
   ],
@@ -24,7 +30,7 @@
     },
     {
       "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": ["12.04", "14.04", "16.04"]
+      "operatingsystemrelease": ["12.04", "14.04", "16.04", "17.04"]
     },
     {
       "operatingsystem": "Windows",

--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,6 @@
     {"name": "puppetlabs/apt", "version_requirement": ">= 2.1.1 < 3.0.0"},
     {"name": "puppetlabs/chocolatey", "version_requirement": ">= 0.8.0 < 2.0.0"},
     {"name": "puppetlabs/vcsrepo", "version_requirement": ">= 2.0.0 < 3.0.0"},
-    {"name": "computology/packagecloud", "version_requirement": ">= 0.3.2 < 0.4.0"},
     {"name": "thekevjames/homebrew", "version_requirement": ">= 1.5.0 < 2.0.0"},
     {"name": "unibet/vagrant", "version_requirement": ">= 0.2.1 < 1.0.0"}
   ],


### PR DESCRIPTION
This PR adds a first shot of Slack installation, supporting Ubuntu only for now:

1. Downloads the installation package (`.deb`) from the [Slack download site](https://slack.com/downloads)
2. Installs the downloaded package using `dpkg`

Fixes #1.