### PR TITLE
Add gitconfig and gitignore parameters (Git)

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,6 @@ fixtures:
   repositories:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
+    vcsrepo: "https://github.com/puppetlabs/puppetlabs-vcsrepo.git"
   symlinks:
     software: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ software::editors::atom::packages:
 software::editors::atom::themes:
   twilight-syntax: {}
 software::editors::atom::user: username
+
+software::vcsscm::git:
+  gui: true
+  bash_completion: true
+  bash_prompt: true
+  gitconfig: true
+  gitignore: puppet:///modules/custom/user/gitignore
 ```
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ classes:
 - software::editors::atom
 - software::entertainment::vlc
 - software::social::skype
+- software::vcsscm::git
 
 software::browsers::chrome::channel: stable
 

--- a/files/vcsscm/git/system-gitconfig
+++ b/files/vcsscm/git/system-gitconfig
@@ -1,5 +1,4 @@
 # System-global Git configuration. https://git-scm.com/docs/git-config#FILES
 
 [alias]
-	permission-reset = "!git diff -p | grep -E \"^(diff|old mode|new mode)\" | sed -e \"s/^old/NEW/;s/^new/old/;s/^NEW/new/\" | git apply"
 	undo-commit = reset --soft HEAD^

--- a/files/vcsscm/git/system-gitconfig
+++ b/files/vcsscm/git/system-gitconfig
@@ -1,0 +1,5 @@
+# System-global Git configuration. https://git-scm.com/docs/git-config#FILES
+
+[alias]
+	permission-reset = "!git diff -p | grep -E \"^(diff|old mode|new mode)\" | sed -e \"s/^old/NEW/;s/^new/old/;s/^NEW/new/\" | git apply"
+	undo-commit = reset --soft HEAD^

--- a/files/vcsscm/git/user-gitconfig
+++ b/files/vcsscm/git/user-gitconfig
@@ -1,4 +1,1 @@
 # User-global Git configuration. See /etc/gitconfig for system-global settings.
-
-[sequence]
-	editor = emacs -nw

--- a/files/vcsscm/git/user-gitconfig
+++ b/files/vcsscm/git/user-gitconfig
@@ -1,0 +1,4 @@
+# User-global Git configuration. See /etc/gitconfig for system-global settings.
+
+[sequence]
+	editor = emacs -nw

--- a/files/vcsscm/git/user-gitignore
+++ b/files/vcsscm/git/user-gitignore
@@ -1,0 +1,58 @@
+# Global Git Ignore. https://git-scm.com/docs/gitignore
+
+# Special files and folder of various OSes
+.AppleDesktop
+.AppleDB
+.AppleDouble
+.apdisk
+.com.apple.timemachine.donotpresent
+Desktop.ini
+.directory
+*.DS_Store
+.fseventsd
+.fuse_hidden*
+.LSOverride
+Network Trash Folder
+.nfs*
+$RECYCLE.BIN/
+.Spotlight-V100
+.TemporaryItems
+Temporary Items
+.Trash-*
+.Trashes
+.VolumeIcon.icns
+
+# Various cache files and folders
+.cache
+.eggs/
+*.egg-info/
+.eslintcache
+Thumbs.db
+webassets-cache
+
+# Build files and folders
+**/material-design-icons/*/ios/*.imageset/Contents.json
+**/material-design-icons/sprites/
+**/material-design-icons/iconfont/
+**/material-design-icons/*/drawable-anydpi-v21/*.xml
+**/material-design-icons/**/*.png
+**/material-design-icons/*/svg/design/*.svg
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Editor and IDE files and folders
+.idea
+*.stTheme.cache
+*.sublime-project
+*.sublime-workspace
+*.tmlanguage.cache
+*.tmPreferences.cache
+GitHub.sublime-settings
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/

--- a/manifests/vcsscm/git.pp
+++ b/manifests/vcsscm/git.pp
@@ -1,5 +1,5 @@
 # git.pp
-# Install git cli
+# Install git cli, optional tab completion, config and ignore files
 #
 
 class software::vcsscm::git (
@@ -49,30 +49,61 @@ class software::vcsscm::git (
       }
 
       if $gitconfig {
-        file { '/etc/gitconfig':
-          ensure => file,
-          owner  => 'root',
-          group  => 'root',
-          mode   => '0644',
-          source => 'puppet:///modules/software/vcsscm/git/system-gitconfig',
+
+        if $gitconfig =~ Boolean {
+          $gitconfig = {
+            'system' =>  'puppet:///modules/software/vcsscm/git/system-gitconfig',
+            'user'   =>  'puppet:///modules/software/vcsscm/git/user-gitconfig',
+          }
+        }
+        elsif $gitconfig =~ String {
+          $gitconfig = {
+            'user' => $gitconfig,
+          }
         }
 
-        file { '/etc/skel/.config/git/config':
-          ensure => file,
-          owner  => 'root',
-          group  => 'root',
-          mode   => '0644',
-          source => 'puppet:///modules/software/vcsscm/git/user-gitconfig',
+        if $gitconfig['system'] {
+          file { '/etc/gitconfig':
+            ensure => file,
+            owner  => 'root',
+            group  => 'root',
+            mode   => '0644',
+            source => $gitconfig['system'],
+          }
+        }
+
+        if $gitconfig['user'] {
+          file { '/etc/skel/.config/git/config':
+            ensure => file,
+            owner  => 'root',
+            group  => 'root',
+            mode   => '0644',
+            source => $gitconfig['user'],
+          }
         }
       }
 
       if $gitignore {
-        file { '/etc/skel/.config/git/ignore':
-          ensure => file,
-          owner  => 'root',
-          group  => 'root',
-          mode   => '0644',
-          source => 'puppet:///modules/software/vcsscm/git/user-gitignore',
+
+        if $gitignore =~ Boolean {
+          $gitignore = {
+            'user' => 'puppet:///modules/software/vcsscm/git/user-gitignore',
+          }
+        }
+        elsif $gitignore =~ String {
+          $gitignore = {
+            'user' => $gitignore,
+          }
+        }
+
+        if $gitignore['user'] {
+          file { '/etc/skel/.config/git/ignore':
+            ensure => file,
+            owner  => 'root',
+            group  => 'root',
+            mode   => '0644',
+            source => $gitignore['user'],
+          }
         }
       }
     }

--- a/manifests/vcsscm/git.pp
+++ b/manifests/vcsscm/git.pp
@@ -7,6 +7,8 @@ class software::vcsscm::git (
   $gui             = false,
   $bash_completion = false,
   $bash_prompt     = false,
+  $gitconfig       = false,
+  $gitignore       = false,
 ) inherits software::params {
 
   validate_string($ensure)
@@ -43,6 +45,34 @@ class software::vcsscm::git (
           group  => 'root',
           mode   => '0644',
           source => 'puppet:///modules/software/vcsscm/git/bash-git-prompt',
+        }
+      }
+
+      if $gitconfig {
+        file { '/etc/gitconfig':
+          ensure => file,
+          owner  => 'root',
+          group  => 'root',
+          mode   => '0644',
+          source => 'puppet:///modules/software/vcsscm/git/system-gitconfig',
+        }
+
+        file { '/etc/skel/.config/git/config':
+          ensure => file,
+          owner  => 'root',
+          group  => 'root',
+          mode   => '0644',
+          source => 'puppet:///modules/software/vcsscm/git/user-gitconfig',
+        }
+      }
+
+      if $gitignore {
+        file { '/etc/skel/.config/git/ignore':
+          ensure => file,
+          owner  => 'root',
+          group  => 'root',
+          mode   => '0644',
+          source => 'puppet:///modules/software/vcsscm/git/user-gitignore',
         }
       }
     }

--- a/manifests/vcsscm/git.pp
+++ b/manifests/vcsscm/git.pp
@@ -62,11 +62,10 @@ class software::vcsscm::git (
 
         if !defined(File['/etc/skel/.config/git']) {
           file { '/etc/skel/.config/git':
-            ensure  => directory,
-            owner   => 'root',
-            group   => 'root',
-            mode    => '0755',
-            require => File['/etc/skel/.config'],
+            ensure => directory,
+            owner  => 'root',
+            group  => 'root',
+            mode   => '0755',
           }
         }
       }
@@ -101,12 +100,11 @@ class software::vcsscm::git (
         if $gitconfig_user {
 
           file { '/etc/skel/.config/git/config':
-            ensure  => file,
-            owner   => 'root',
-            group   => 'root',
-            mode    => '0644',
-            source  => $gitconfig_user,
-            require => File['/etc/skel/.config/git'],
+            ensure => file,
+            owner  => 'root',
+            group  => 'root',
+            mode   => '0644',
+            source => $gitconfig_user,
           }
         }
       }
@@ -123,12 +121,11 @@ class software::vcsscm::git (
         if $gitignore_user {
 
           file { '/etc/skel/.config/git/ignore':
-            ensure  => file,
-            owner   => 'root',
-            group   => 'root',
-            mode    => '0644',
-            source  => $gitignore_user,
-            require => File['/etc/skel/.config/git'],
+            ensure => file,
+            owner  => 'root',
+            group  => 'root',
+            mode   => '0644',
+            source => $gitignore_user,
           }
         }
       }

--- a/manifests/vcsscm/git.pp
+++ b/manifests/vcsscm/git.pp
@@ -49,7 +49,12 @@ class software::vcsscm::git (
       }
 
       if $gitconfig or $gitignore {
-        file { ['/etc/skel', '/etc/skel/.config', '/etc/skel/.config/git']:
+        # Ensure target path (avoiding to manage base path)
+        exec { 'mkdir -p /etc/skel/.config':
+          creates => '/etc/skel/.config',
+          path    => ['/usr/bin'],
+        }
+        -> file { '/etc/skel/.config/git':
           ensure => directory,
           owner  => 'root',
           group  => 'root',

--- a/manifests/vcsscm/git.pp
+++ b/manifests/vcsscm/git.pp
@@ -48,6 +48,15 @@ class software::vcsscm::git (
         }
       }
 
+      if $gitconfig or $gitignore {
+        file { ['/etc/skel', '/etc/skel/.config', '/etc/skel/.config/git']:
+          ensure => directory,
+          owner  => 'root',
+          group  => 'root',
+          mode   => '0755',
+        }
+      }
+
       if $gitconfig {
 
         if $gitconfig =~ Boolean {

--- a/manifests/vcsscm/git.pp
+++ b/manifests/vcsscm/git.pp
@@ -51,34 +51,35 @@ class software::vcsscm::git (
       if $gitconfig {
 
         if $gitconfig =~ Boolean {
-          $gitconfig = {
-            'system' =>  'puppet:///modules/software/vcsscm/git/system-gitconfig',
-            'user'   =>  'puppet:///modules/software/vcsscm/git/user-gitconfig',
-          }
+          $gitconfig_system = 'puppet:///modules/software/vcsscm/git/system-gitconfig'
+          $gitconfig_user = 'puppet:///modules/software/vcsscm/git/user-gitconfig'
         }
         elsif $gitconfig =~ String {
-          $gitconfig = {
-            'user' => $gitconfig,
-          }
+          $gitconfig_system = false
+          $gitconfig_user = $gitconfig
+        }
+        else {  # must be associative Array otherwise
+          $gitconfig_system = $gitconfig['system']
+          $gitconfig_user = $gitconfig['user']
         }
 
-        if $gitconfig['system'] {
+        if $gitconfig_system {
           file { '/etc/gitconfig':
             ensure => file,
             owner  => 'root',
             group  => 'root',
             mode   => '0644',
-            source => $gitconfig['system'],
+            source => $gitconfig_system,
           }
         }
 
-        if $gitconfig['user'] {
+        if $gitconfig_user {
           file { '/etc/skel/.config/git/config':
             ensure => file,
             owner  => 'root',
             group  => 'root',
             mode   => '0644',
-            source => $gitconfig['user'],
+            source => $gitconfig_user,
           }
         }
       }
@@ -86,23 +87,22 @@ class software::vcsscm::git (
       if $gitignore {
 
         if $gitignore =~ Boolean {
-          $gitignore = {
-            'user' => 'puppet:///modules/software/vcsscm/git/user-gitignore',
-          }
+          $gitignore_user = 'puppet:///modules/software/vcsscm/git/user-gitignore'
         }
         elsif $gitignore =~ String {
-          $gitignore = {
-            'user' => $gitignore,
-          }
+          $gitignore_user = $gitignore
+        }
+        else {  # must be associative Array otherwise
+          $gitignore_user = $gitignore['user']
         }
 
-        if $gitignore['user'] {
+        if $gitignore_user {
           file { '/etc/skel/.config/git/ignore':
             ensure => file,
             owner  => 'root',
             group  => 'root',
             mode   => '0644',
-            source => $gitignore['user'],
+            source => $gitignore_user,
           }
         }
       }

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     {"name": "puppetlabs/stdlib", "version_requirement": ">= 4.2.0 < 5.0.0"},
     {"name": "puppetlabs/apt", "version_requirement": ">= 2.1.1 < 3.0.0"},
     {"name": "puppetlabs/chocolatey", "version_requirement": ">= 0.8.0 < 2.0.0"},
-    {"name": "puppetlabs/vcsrepo", "version_requirement": ">= 2.0.0 < 3.0.0"},
+    {"name": "puppetlabs/vcsrepo", "version_requirement": ">= 1.3.1 < 3.0.0"},
     {"name": "thekevjames/homebrew", "version_requirement": ">= 1.5.0 < 2.0.0"},
     {"name": "unibet/vagrant", "version_requirement": ">= 0.2.1 < 1.0.0"}
   ],

--- a/spec/classes/software_vcsscm_git_spec.rb
+++ b/spec/classes/software_vcsscm_git_spec.rb
@@ -13,6 +13,134 @@ describe 'software::vcsscm::git' do
         else
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_package('git') }
+          it { is_expected.not_to contain_package('gitk') }
+          it { is_expected.not_to contain_package('git-gui') }
+          it { is_expected.not_to contain_package('bash-completion') }
+          it { is_expected.not_to contain_vcsrepo('/opt/bash-git-prompt/') }
+          it { is_expected.not_to contain_file('/etc/bash_completion.d/bash-git-prompt') }
+          it { is_expected.not_to contain_file('/etc/gitconfig') }
+          it { is_expected.not_to contain_file('/etc/skel/.config/git/config') }
+          it { is_expected.not_to contain_file('/etc/skel/.config/git/ignore') }
+        end
+      end
+
+      context 'with gui' do
+        let :params do
+          {
+            :gui => true
+          }
+        end
+        if facts[:operatingsystem] == 'Darwin'
+          it { is_expected.to compile.and_raise_error(/is not supported on Darwin./) }
+        else
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_package('git') }
+          it { is_expected.to contain_package('gitk') }
+          it { is_expected.to contain_package('git-gui') }
+        end
+      end
+
+      context 'with bash completion and prompt' do
+        let :params do
+          {
+            :bash_completion => true,
+            :bash_prompt     => true
+          }
+        end
+        if facts[:operatingsystem] == 'Darwin'
+          it { is_expected.to compile.and_raise_error(/is not supported on Darwin./) }
+        else
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_package('git') }
+          it { is_expected.to contain_package('bash-completion') }
+          it { is_expected.to contain_vcsrepo('/opt/bash-git-prompt/') }
+          it {
+            is_expected.to contain_file('/etc/bash_completion.d/bash-git-prompt')
+              .with_source('puppet:///modules/software/vcsscm/git/bash-git-prompt')
+          }
+        end
+      end
+
+      context 'with booleans for gitconfig and gitignore' do
+        let :params do
+          {
+            :gitconfig => true,
+            :gitignore => true
+          }
+        end
+        if facts[:operatingsystem] == 'Darwin'
+          it { is_expected.to compile.and_raise_error(/is not supported on Darwin./) }
+        else
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_package('git') }
+          it {
+            is_expected.to contain_file('/etc/gitconfig')
+              .with_source('puppet:///modules/software/vcsscm/git/system-gitconfig')
+          }
+          it {
+            is_expected.to contain_file('/etc/skel/.config/git/config')
+              .with_source('puppet:///modules/software/vcsscm/git/user-gitconfig')
+          }
+          it {
+            is_expected.to contain_file('/etc/skel/.config/git/ignore')
+              .with_source('puppet:///modules/software/vcsscm/git/user-gitignore')
+          }
+        end
+      end
+
+      context 'with strings for gitconfig and gitignore' do
+        let :params do
+          {
+            :gitconfig => 'puppet:///modules/software/vcsscm/git/user-gitconfig',
+            :gitignore => 'puppet:///modules/software/vcsscm/git/user-gitignore'
+          }
+        end
+        if facts[:operatingsystem] == 'Darwin'
+          it { is_expected.to compile.and_raise_error(/is not supported on Darwin./) }
+        else
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_package('git') }
+          it { is_expected.not_to contain_file('/etc/gitconfig') }
+          it {
+            is_expected.to contain_file('/etc/skel/.config/git/config')
+              .with_source('puppet:///modules/software/vcsscm/git/user-gitconfig')
+          }
+          it {
+            is_expected.to contain_file('/etc/skel/.config/git/ignore')
+              .with_source('puppet:///modules/software/vcsscm/git/user-gitignore')
+          }
+        end
+      end
+
+      context 'with hashes for gitconfig and gitignore' do
+        let :params do
+          {
+            :gitconfig => {
+              :system => 'puppet:///modules/software/vcsscm/git/system-gitconfig',
+              :user   => 'puppet:///modules/software/vcsscm/git/user-gitconfig'
+            },
+            :gitignore => {
+              :user => 'puppet:///modules/software/vcsscm/git/user-gitignore'
+            }
+          }
+        end
+        if facts[:operatingsystem] == 'Darwin'
+          it { is_expected.to compile.and_raise_error(/is not supported on Darwin./) }
+        else
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_package('git') }
+          it {
+            is_expected.to contain_file('/etc/gitconfig')
+              .with_source('puppet:///modules/software/vcsscm/git/system-gitconfig')
+          }
+          it {
+            is_expected.to contain_file('/etc/skel/.config/git/config')
+              .with_source('puppet:///modules/software/vcsscm/git/user-gitconfig')
+          }
+          it {
+            is_expected.to contain_file('/etc/skel/.config/git/ignore')
+              .with_source('puppet:///modules/software/vcsscm/git/user-gitignore')
+          }
         end
       end
     end

--- a/spec/classes/software_vcsscm_git_spec.rb
+++ b/spec/classes/software_vcsscm_git_spec.rb
@@ -91,8 +91,8 @@ describe 'software::vcsscm::git' do
       context 'with strings for gitconfig and gitignore' do
         let :params do
           {
-            :gitconfig => 'puppet:///modules/software/vcsscm/git/user-gitconfig',
-            :gitignore => 'puppet:///modules/software/vcsscm/git/user-gitignore'
+            :gitconfig => 'puppet:///modules/user-supplied/custom/user-gitconfig',
+            :gitignore => 'puppet:///modules/user-supplied/custom/user-gitignore'
           }
         end
         if facts[:operatingsystem] == 'Darwin'
@@ -103,11 +103,11 @@ describe 'software::vcsscm::git' do
           it { is_expected.not_to contain_file('/etc/gitconfig') }
           it {
             is_expected.to contain_file('/etc/skel/.config/git/config')
-              .with_source('puppet:///modules/software/vcsscm/git/user-gitconfig')
+              .with_source('puppet:///modules/user-supplied/custom/user-gitconfig')
           }
           it {
             is_expected.to contain_file('/etc/skel/.config/git/ignore')
-              .with_source('puppet:///modules/software/vcsscm/git/user-gitignore')
+              .with_source('puppet:///modules/user-supplied/custom/user-gitignore')
           }
         end
       end
@@ -116,11 +116,11 @@ describe 'software::vcsscm::git' do
         let :params do
           {
             :gitconfig => {
-              :system => 'puppet:///modules/software/vcsscm/git/system-gitconfig',
-              :user   => 'puppet:///modules/software/vcsscm/git/user-gitconfig'
+              :system => 'puppet:///modules/user-supplied/custom/system-gitconfig',
+              :user   => 'puppet:///modules/user-supplied/custom/user-gitconfig'
             },
             :gitignore => {
-              :user => 'puppet:///modules/software/vcsscm/git/user-gitignore'
+              :user => 'puppet:///modules/user-supplied/custom/user-gitignore'
             }
           }
         end
@@ -131,15 +131,15 @@ describe 'software::vcsscm::git' do
           it { is_expected.to contain_package('git') }
           it {
             is_expected.to contain_file('/etc/gitconfig')
-              .with_source('puppet:///modules/software/vcsscm/git/system-gitconfig')
+              .with_source('puppet:///modules/user-supplied/custom/system-gitconfig')
           }
           it {
             is_expected.to contain_file('/etc/skel/.config/git/config')
-              .with_source('puppet:///modules/software/vcsscm/git/user-gitconfig')
+              .with_source('puppet:///modules/user-supplied/custom/user-gitconfig')
           }
           it {
             is_expected.to contain_file('/etc/skel/.config/git/ignore')
-              .with_source('puppet:///modules/software/vcsscm/git/user-gitignore')
+              .with_source('puppet:///modules/user-supplied/custom/user-gitignore')
           }
         end
       end


### PR DESCRIPTION
Adds two parameters to the `software::vcsscm::git` class:

- `gitconfig` (`false`): Add both a system-global and a user-global `.git/config` file to the host
- `gitignore` (`false`): Add a user-global `.git/ignore` file to the host

Fixes #8.

Envisioned Concept
========
Currently, when one of those parameters is set to `true` the files are installed based on the idea of "sensible defaults". They should be generally suitable, practically for "everyone". But not worthless, i.e. empty files.

If future, the parameters may allow to specify a Puppet URL (`'puppet:///modules/...`) or something similar in order to override the files provided by the `software` Puppet module. For the `gitconfig` parameter that would entail to handle 4 cases: (Examples)

Edge Cases
---------------

1. Create only a user-global gitconfig file (no system-global):
```puppet
  gitconfig => 'puppet://module/...'
```

2.-4. Create both files, or only one of them:
```puppet
  gitconfig => {
    'system' => 'puppet:///module/...',
    'user'   => 'puppet:///module/...',
  }
```
Case 1. would hence (have to) be equivalent to:
```puppet
  gitconfig => {
    'user'   => 'puppet:///module/...',
  }
```
The non-specified files would have to be removed (by default) to leave the host in a predictable state.
