### PR TITLE
Add PDK to idesdk section

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ include software::editors::textmate
 include software::entertainment::vlc
 include software::idesdk::android_studio
 include software::idesdk::android_tools
+include software::idesdk::pdk
 include software::prefpanes::hosts
 include software::prefpanes::launchrocket
 include software::social::skype

--- a/manifests/idesdk/pdk.pp
+++ b/manifests/idesdk/pdk.pp
@@ -20,7 +20,7 @@ class software::idesdk::pdk (
       }
 
       file { '/tmp/pdk.deb':
-        source  => $url,
+        source => $url,
         owner  => 'root',
         group  => 'root',
         mode   => '0644',

--- a/manifests/idesdk/pdk.pp
+++ b/manifests/idesdk/pdk.pp
@@ -1,0 +1,35 @@
+# pdk.pp
+# Install Puppet Development Kit
+# https://puppet.com/download-puppet-development-kit
+#
+
+class software::idesdk::pdk (
+  $ensure  = $software::params::software_ensure,
+  $version = $software::params::pdk_version,
+  $url     = $software::params::pdk_url,
+) inherits software::params {
+
+  validate_string($ensure)
+
+  case $::operatingsystem {
+    'Ubuntu': {
+      package { 'pdk':
+        ensure   => $ensure,
+        source   => '/tmp/pdk.deb',
+        provider => 'dpkg',
+      }
+
+      file { '/tmp/pdk.deb':
+        source  => $url,
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0644',
+        before => Package['pdk'],
+      }
+    }
+    default: {
+      fail("The ${name} class is not supported on ${::operatingsystem}.")
+    }
+  }
+
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -54,6 +54,8 @@ class software::params (
     # ### idesdk ####
     $android_studio_version = '145.3537739'
     $android_studio_url     = "https://dl.google.com/dl/android/studio/install/2.2.3.0/android-studio-ide-${android_studio_version}-mac.dmg"
+    $pdk_version            = undef
+    $pdk_url                = undef
 
 
     # ### prefpanes ####
@@ -142,13 +144,13 @@ class software::params (
     $atom_url = 'https://atom.io/download/deb'
 
 
-    #### idesdk ####
+    # ### idesdk ####
     $pdk_version  = 'latest'
     $pdk_url_base = 'https://pm.puppetlabs.com/cgi-bin/pdk_download.cgi'
     $pdk_url      = "${pdk_url_base}?dist=ubuntu&rel=16.04&arch=${::architecture}&ver=${pdk_version}"
 
 
-    #### social ####
+    # ### social ####
     $skype_version = undef
     $skype_url     = undef
 
@@ -191,6 +193,11 @@ class software::params (
 
     # ### editors ####
     $atom_url = undef
+
+
+    # ### idesdk ####
+    $pdk_version = undef
+    $pdk_url     = undef
 
 
     # ### social ####

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -142,7 +142,13 @@ class software::params (
     $atom_url = 'https://atom.io/download/deb'
 
 
-    # ### social ####
+    #### idesdk ####
+    $pdk_version  = 'latest'
+    $pdk_url_base = 'https://pm.puppetlabs.com/cgi-bin/pdk_download.cgi'
+    $pdk_url      = "${pdk_url_base}?dist=ubuntu&rel=16.04&arch=${::architecture}&ver=${pdk_version}"
+
+
+    #### social ####
     $skype_version = undef
     $skype_url     = undef
 

--- a/spec/classes/software_idesdk_pdk_spec.rb
+++ b/spec/classes/software_idesdk_pdk_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe 'software::idesdk::pdk' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+
+      context 'with defaults' do
+        if facts[:operatingsystem] == 'Ubuntu'
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_file('/tmp/pdk.deb') }
+          it { is_expected.to contain_package('pdk') }
+        else
+          it { is_expected.to compile.and_raise_error(/is not supported on /) }
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/software_idesdk_pdk_spec.rb
+++ b/spec/classes/software_idesdk_pdk_spec.rb
@@ -13,7 +13,7 @@ describe 'software::idesdk::pdk' do
           it { is_expected.to contain_file('/tmp/pdk.deb') }
           it { is_expected.to contain_package('pdk') }
         else
-          it { is_expected.to compile.and_raise_error(/is not supported on /) }
+          it { is_expected.to compile.and_raise_error(%r{is not supported on }) }
         end
       end
     end


### PR DESCRIPTION
These changes add PDK, the [Puppet Development Kit](https://puppet.com/download-puppet-development-kit), to the idesdk section. This is meant to live in this repo as long as Puppetlab's packages are not yet installable off repository servers (using the Puppet `package` resource).

Fixes #14.